### PR TITLE
Handle empty .git/index

### DIFF
--- a/updater/lib/sync-repos.bash
+++ b/updater/lib/sync-repos.bash
@@ -59,7 +59,13 @@ function SyncRepos {
             visited_dirs["$prefix_d"]=1
         done
 
-	if [ -d "$dir" ]
+        if [ -d "$dir" ] && ! [ -s "$dir"/.git/index ]
+        then
+            Log "corrupt $dir/.git/index"
+            rm -rf "$dir"
+        fi
+
+        if [ -d "$dir" ]
         then
             Log "updating $dir"
             pushd "$dir" > /dev/null


### PR DESCRIPTION
Sometimes, .git/index ends up as size 0.  In these cases, report it as corrupt, remove the repo, and clone a new.